### PR TITLE
Js turn into GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ jmsudar.UpdateCSProj is a .NET library for automating updates to .csproj files. 
 - Efficiently updates .csproj files with provided command-line arguments.
 - Reads, processes, and writes back changes to the original .csproj file.
 - Supports a wide range of properties within the PropertyGroup section.
+- Available as a reusable GitHub Action for seamless integration into CI/CD workflows.
+
 
 ## Usage
+
+### As a Console Application
 
 This project is meant to be used as a console application. Specifically, it was designed to be used as part of a CI/CD workflow such as GitHub Actions. It will read and edit a .csproj file in place, preserving any structure outside the `PropertyGroup` block. It will also ignore any null blocks, so you need not use all the arguments in the example block below.
 
@@ -17,6 +21,40 @@ Any CI/CD platform that can perform a `dotnet run` command can use this project.
 ```sh
 dotnet run --filePath=path/to/your/project.csproj --packageId=your.Package.ID --version=1.0.0 --authors=JMSudar --description="Your description here" --packageTags="tag1;tag2" --repositoryUrl=https://github.com/your/repo --packageLicenseExpression=GPL-3.0-or-later --packageProjectUrl=https://github.com/your/repo --packageReadmeFile=README.md
 ```
+
+### As a GitHub Action
+
+You can now use jmsudar.UpdateCSProj directly within your GitHub Actions workflows. This action allows you to update .csproj files as part of your CI/CD pipeline, ensuring your project metadata is always up-to-date.
+
+To run this as an action, include a block following the pattern of the step below in your CD workflow.
+
+```shell
+- name: Update .csproj file
+uses: jmsudar/UpdateCSProj@v1
+with:
+    file-path: 'src/YourProject/YourProject.csproj'
+    package-id: 'com.example.YourProject'
+    version: '1.0.0'
+    package-tags: 'utility,automation'
+    package-license: 'MIT'
+```
+
+#### Input Parameters
+
+The following input parameters are supported when used as a GitHub Action.
+
+- file-path: (Required) The path to the .csproj file you want to update.
+- target-framework: Specifies the .NET framework version for your project. Defaults to net6.0 but should be set based on your project’s requirements.
+- implicit-usings: Determines whether to use implicit using directives. Set to true to enable, false to disable. Defaults to false.
+- nullable: Enables or disables nullable reference types. Set to true to enable, false to disable. Defaults to true.
+- package-id: (Required) The unique package ID for your project, typically following the reverse domain name notation, e.g., com.example.project.
+- version: (Required) The version number for your project, e.g., 1.0.0.
+- author: Specifies the author of the project. Defaults to the GitHub repository owner but can be set to any string or multiple owners.
+- package-tags: Tags for your package to help categorize it, separated by commas, e.g., utility,automation.
+- repository-url: The URL of your project’s GitHub repository. Defaults to git@github.com:<owner>/<repository>.git, but you can override it with a different URL.
+- package-license: (Required) The license under which your project is distributed, e.g., MIT, GPL-3.0.
+- package-project-url: The URL of your project’s homepage or main page. Defaults to your repository URL. Defaults to git@github.com:<owner>/<repository>.git, but you can override it with a different URL.
+- package-readme-file: The path to your README file to include in your package. Defaults to README.md.
 
 ## License
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,117 @@
+name: Update CSProj
+
+on:
+  workflow_dispatch:
+    inputs:
+      file-path:
+        description: 'The path to the csproj file'
+        required: true
+        default: ''
+      target-framework:
+        description: 'The framework for your dotnet build'
+        required: true
+        default: '6.0'
+      implicit-usings:
+        description: 'Whether or not to use implicit usings'
+        required: true
+        default: 'false'
+      nullable:
+        description: 'Whether or not to use nullable reference types'
+        required: true
+        default: 'false'
+      package-id:
+        description: 'The package id for your project'
+        required: true
+        default: ''
+      version:
+        description: 'The current version for your project'
+        required: true
+        default: ''
+      author:
+        description: |
+          The author of the project 
+          Defaults to repo owner
+        required: true
+        default: ${{ github.repository_owner }}
+      package-tags:
+        description: 'The tags for your package'
+        required: false
+        default: ''
+      repository-url:
+        description: |
+          The repository URL for your project
+          Defaults to 'git@github.com:${{ github.repository }}.git'
+        required: true
+        default: 'git@github.com:${{ github.repository }}.git'
+      package-license:
+        description: 'The license for your package'
+        required: true
+        default: ''
+      package-project-url:
+        description: |
+          The project URL for your package
+          Defaults to 'git@github.com:${{ github.repository }}.git'
+        required: true
+        default: 'git@github.com:${{ github.repository }}.git'
+      package-readme-file:
+        description: 'The readme file for your package'
+        required: true
+        default: 'README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check required inputs
+        env:
+          FILE_PATH: ${{ inputs.file-path }}
+          PACKAGE_ID: ${{ inputs.package-id }}
+          VERSION: ${{ inputs.version }}
+          PACKAGE_LICENSE: ${{ inputs.package-license }}
+        run: |
+          if [[ -z "${FILE_PATH}" || -z "${PACKAGE_ID}" || -z "${VERSION}" || -z "${PACKAGE_LICENSE}" ]]; then
+            echo "One or more required inputs are missing."
+            echo "file-path: ${FILE_PATH}"
+            echo "package-id: ${PACKAGE_ID}"
+            echo "version: ${VERSION}"
+            echo "package-license: ${PACKAGE_LICENSE}"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.target-framework }}
+
+      - name: Build and run UpdateCSProj
+        env:
+          FILE_PATH: ${{ inputs.file-path }}
+          TARGET_FRAMEWORK: ${{ inputs.target-framework }}
+          IMPLICIT_USINGS: ${{ inputs.implicit-usings }}
+          NULLABLE: ${{ inputs.nullable }}
+          PACKAGE_ID: ${{ inputs.package-id }}
+          VERSION: ${{ inputs.version }}
+          AUTHOR: ${{ inputs.author }}
+          PACKAGE_TAGS: ${{ inputs.package-tags }}
+          REPOSITORY_URL: ${{ inputs.repository-url }}
+          PACKAGE_LICENSE: ${{ inputs.package-license }}
+          PACKAGE_PROJECT_URL: ${{ inputs.package-project-url }}
+          PACKAGE_README_FILE: ${{ inputs.package-readme-file }}
+        run: |
+          dotnet run --project UpdateCSProj.csproj \
+            --filePath ${FILE_PATH} \
+            --targetFramework ${TARGET_FRAMEWORK} \
+            --implicitUsings ${IMPLICIT_USINGS} \
+            --nullable ${NULLABLE} \
+            --packageId ${PACKAGE_ID} \
+            --version ${VERSION} \
+            --author ${AUTHOR} \
+            --packageTags ${PACKAGE_TAGS} \
+            --repositoryUrl ${REPOSITORY_URL} \
+            --packageLicense ${PACKAGE_LICENSE} \
+            --packageProjectUrl ${PACKAGE_PROJECT_URL} \
+            --packageReadmeFile ${PACKAGE_README_FILE}

--- a/action.yaml
+++ b/action.yaml
@@ -14,11 +14,11 @@ on:
       implicit-usings:
         description: 'Whether or not to use implicit usings'
         required: true
-        default: 'false'
+        default: false
       nullable:
         description: 'Whether or not to use nullable reference types'
         required: true
-        default: 'false'
+        default: true
       package-id:
         description: 'The package id for your project'
         required: true

--- a/src/UpdateCSProj.Tests/UpdateCSProj.Test.cs
+++ b/src/UpdateCSProj.Tests/UpdateCSProj.Test.cs
@@ -25,7 +25,10 @@ public class UpdateCSProjTests
     [TestCleanup]
     public void Cleanup()
     {
-        File.Delete(_tempFilePath);
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
     }
 
     [TestMethod]
@@ -46,6 +49,11 @@ public class UpdateCSProjTests
 
         UpdateCSProj.Main(args);
 
+        if (_tempFilePath == null)
+        {
+            Assert.Fail("Temp file path is null");
+            return;
+        }
         string updatedContent = File.ReadAllText(_tempFilePath);
         Assert.IsTrue(updatedContent.Contains("<PackageId>jmsudar.DotNet.Xml</PackageId>"));
         Assert.IsTrue(updatedContent.Contains("<Version>1.2.0</Version>"));
@@ -76,6 +84,11 @@ public class UpdateCSProjTests
 
         UpdateCSProj.Main(args);
 
+        if (_tempFilePath == null)
+        {
+            Assert.Fail("Temp file path is null");
+            return;
+        }
         string updatedContent = File.ReadAllText(_tempFilePath);
         Assert.IsTrue(updatedContent.Contains("<PackageId>jmsudar.DotNet.Xml</PackageId>"));
         Assert.IsTrue(updatedContent.Contains("<Version>1.2.0</Version>"));


### PR DESCRIPTION
# Overview

- Includes a new `action.yaml` file that allows this to be used directly as a GitHub Action.
- Updates `README.md` with data on how to run this as an Action, as well as documenting the input parameters.
- Cleans up three warnings related to possible null values in the Tests file. 