### PR TITLE
Update action.yaml to not use github events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ with:
   file-path: 'src/YourProject/YourProject.csproj'
   package-id: 'com.example.YourProject'
   version: '1.0.0'
+  author: 'Jane Doe'
   package-tags: 'utility,automation'
   package-license: 'MIT'
 ```
@@ -49,11 +50,11 @@ The following input parameters are supported when used as a GitHub Action.
 - nullable: Enables or disables nullable reference types. Set to true to enable, false to disable. Defaults to true.
 - package-id: (Required) The unique package ID for your project, typically following the reverse domain name notation, e.g., com.example.project.
 - version: (Required) The version number for your project, e.g., 1.0.0.
-- author: Specifies the author of the project. Defaults to the GitHub repository owner but can be set to any string or multiple owners.
+- author: Specifies the author of the project. Can be set to any string or multiple owners.
 - package-tags: Tags for your package to help categorize it, separated by commas, e.g., utility,automation.
-- repository-url: The URL of your project’s GitHub repository. Defaults to git@github.com:<owner>/<repository>.git, but you can override it with a different URL.
+- repository-url: The URL of your project’s GitHub repository.
 - package-license: (Required) The license under which your project is distributed, e.g., MIT, GPL-3.0.
-- package-project-url: The URL of your project’s homepage or main page. Defaults to your repository URL. Defaults to git@github.com:<owner>/<repository>.git, but you can override it with a different URL.
+- package-project-url: The URL of your project’s homepage or main page. Defaults to your repository URL.
 - package-readme-file: The path to your README file to include in your package. Defaults to README.md.
 
 ## License

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ on:
           The author of the project 
           Defaults to repo owner
         required: true
-        default: ${{ github.repository_owner }}
+        default: ''
       package-tags:
         description: 'The tags for your package'
         required: false
@@ -40,9 +40,8 @@ on:
       repository-url:
         description: |
           The repository URL for your project
-          Defaults to 'git@github.com:${{ github.repository }}.git'
-        required: true
-        default: 'git@github.com:${{ github.repository }}.git'
+        required: false
+        default: ''
       package-license:
         description: 'The license for your package'
         required: true
@@ -50,9 +49,8 @@ on:
       package-project-url:
         description: |
           The project URL for your package
-          Defaults to 'git@github.com:${{ github.repository }}.git'
-        required: true
-        default: 'git@github.com:${{ github.repository }}.git'
+        required: false
+        default: ''
       package-readme-file:
         description: 'The readme file for your package'
         required: true
@@ -68,13 +66,15 @@ jobs:
           FILE_PATH: ${{ inputs.file-path }}
           PACKAGE_ID: ${{ inputs.package-id }}
           VERSION: ${{ inputs.version }}
+          AUTHOR: ${{ inputs.author }}
           PACKAGE_LICENSE: ${{ inputs.package-license }}
         run: |
-          if [[ -z "${FILE_PATH}" || -z "${PACKAGE_ID}" || -z "${VERSION}" || -z "${PACKAGE_LICENSE}" ]]; then
+          if [[ -z "${FILE_PATH}" || -z "${PACKAGE_ID}" || -z "${VERSION}" || -z "${AUTHOR}" || -z "${PACKAGE_LICENSE}" ]]; then
             echo "One or more required inputs are missing."
             echo "file-path: ${FILE_PATH}"
             echo "package-id: ${PACKAGE_ID}"
             echo "version: ${VERSION}"
+            echo "author: ${AUTHOR}"
             echo "package-license: ${PACKAGE_LICENSE}"
             exit 1
           fi


### PR DESCRIPTION
# Overview

Events following the pattern `${{ github.* }}` are not available in `action.yaml` files. As a result, they need to be removed.