### PR TITLE
Upgrades XML dependency to 1.7.0, which is latest

### DIFF
--- a/src/UpdateCSProj/UpdateCSProj.csproj
+++ b/src/UpdateCSProj/UpdateCSProj.csproj
@@ -16,6 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="jmsudar.DotNet.Xml" Version="1.6.0" />
+    <PackageReference Include="jmsudar.DotNet.Xml" Version="1.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview

During testing, this tool failed to work properly due to an unneeded XML declaration. This PR updates the XML library from `1.6.0` to `1.7.0`, which omits these declarations unless intentionally specified to include them.